### PR TITLE
Renaming: azurerm_autoscale_setting -> azurerm_monitor_autoscale_setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The release the deploy is based on
 
 ## Outputs
 
-### identity
+### identity_principal_id
 The MSI identities set on the web app. Returns a list of identities.
 
 ### identity_tenant_id

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_app_service" "webapp" {
   }
 }
 
-resource "azurerm_autoscale_setting" "app_service_auto_scale" {
+resource "azurerm_monitor_autoscale_setting" "app_service_auto_scale" {
   name                = "${local.autoscale_settings_name}"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"


### PR DESCRIPTION
 Changed autoscale setting resource name to azurerm_monitor_autoscale_setting as in issue #10 . Fixed typo in readme